### PR TITLE
Readme example is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Writing SystemTests
 ```crystal
 require "spec_helper"
 
-class SomeFeatureSpec < GarnetSpec::SystemTestCase
+class SomeFeatureSpec < GarnetSpec::System::Test
   describe "Some Feature test" do
     it "works" do
       visit "http://crystal-lang.org/api"


### PR DESCRIPTION
`GarnetSpec::SystemTestCase` doesn't seem to be a valid class, but `GarnetSpec::System::Test` does. However as in #7, this doesn't work either.