### PR TITLE
Fix broken garnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ dependencies:
     github: amberframework/garnet-spec
 ```
 
+### Installing java
+
+MacOS: `brew cask install java` then `java --version` to verify installation.
+
 ## Usage
 
 Before running your tests ensure you have installed the chromedriver in your system path

--- a/spec/system/test_spec.cr
+++ b/spec/system/test_spec.cr
@@ -5,10 +5,8 @@ class SomeFeature < GarnetSpec::System::Test
     scenario "user visits amber framework and sees getting started button" do
       visit "http://www.amberframework.org"
 
-      timeout 1000
-      click_on(:css, "header a.btn.btn-primary")
       wait 2000
-      element(:tag_name, "body").text.should contain "Introduction"
+      element(:tag_name, "body").text.should contain "Fork the project"
     end
 
     scenario "user visits amberframwork homepage and sees logo" do
@@ -16,7 +14,7 @@ class SomeFeature < GarnetSpec::System::Test
 
       wait 2000
       element(:class_name, "img-amber-logo").attribute("src").should match(
-        %r(https://www.amberframework.org/assets/img/amber-logo-t-bg.png)
+        %r(https://amberframework.org/assets/img/amber-logo-t-bg.png)
       )
     end
   end

--- a/src/garnet_spec/selenium_server.cr
+++ b/src/garnet_spec/selenium_server.cr
@@ -7,7 +7,7 @@ module GarnetSpec
 
     # Boots Selenium Standalone Server
     def self.boot
-      Process.new(command: "selenium-server", output: true, error: true)
+      Process.new(command: "selenium-server", output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
     end
   end
 end


### PR DESCRIPTION
Garnet hasn't been updated since crystal 24.1 dropped, and there was a simple change to the Process API which was broken.

Additionally, the specs pointing to the amber website were broken.

fixes #7, fixes CI failures presenting on #8 