### PR TITLE
[Controller Tests] Adds Missing HTTP Verbs

### DIFF
--- a/src/garnet_spec/controller/test.cr
+++ b/src/garnet_spec/controller/test.cr
@@ -3,7 +3,7 @@ require "http/server"
 module GarnetSpec::Controller
   abstract class Test
     macro inherited
-        {% http_read_verbs = %w(get head) %}
+        {% http_read_verbs = %w(get head options trace connect) %}
         {% http_write_verbs = %w(post put patch delete) %}
         {% http_verbs = http_read_verbs + http_write_verbs %}
 


### PR DESCRIPTION
Garnet should supports all the HTTP verbs available for simulating
requests in a conntroller test. Currently is missing the Options, Trace,
and Connect http verbs

- Adds missing HTTP Read Verbs to generate helper methods for
testing controllers.

With these changes Garnet has available all the HTTP verbs needed.