### PR TITLE
Don't override Content-Type if already given

### DIFF
--- a/spec/controller/test_spec.cr
+++ b/spec/controller/test_spec.cr
@@ -6,7 +6,8 @@ class FakeHandler
   end
 
   def call(context)
-    # Does nothing
+    response = { headers: context.request.headers.to_h }.to_json
+    context.response.write(response.to_slice)
   end
 
   private def prepare_pipelines
@@ -38,6 +39,21 @@ describe GarnetSpec::Controller::Test do
   describe "#post" do
     it "should return a HTTP::Client::Response" do
       subject.post("/posts").should be_a HTTP::Client::Response
+    end
+
+    it "should add Content-Type to headers" do
+      response = JSON.parse(subject.post("/posts").body)
+      headers = response["headers"]?
+      headers.should_not be_nil
+      headers.not_nil!.["Content-Type"].should eq ["application/x-www-form-urlencoded"]
+    end
+
+    it "should not force override of Content-Type" do
+      raw_response = subject.post("/posts", headers: HTTP::Headers{"Content-Type" => "application/json"})
+      response = JSON.parse(raw_response.body)
+      headers = response["headers"]?
+      headers.should_not be_nil
+      headers.not_nil!.["Content-Type"].should eq ["application/json"]
     end
   end
 

--- a/src/garnet_spec/controller/test.cr
+++ b/src/garnet_spec/controller/test.cr
@@ -11,7 +11,7 @@ module GarnetSpec::Controller
           def {{method.id}}(path, headers : HTTP::Headers? = nil, body : String? = nil)
             request = HTTP::Request.new("{{method.id}}".upcase, path, headers, body )
             {% if http_write_verbs.includes? method %}
-              request.headers["Content-Type"] = "application/x-www-form-urlencoded"
+              request.headers["Content-Type"] ||= "application/x-www-form-urlencoded"
             {% end %}
             process_request(request)
           end


### PR DESCRIPTION
I was trying to write controller tests for a controller that was supposed to be a JSON API one. However, when I sent a POST request, something odd was happening to the params. I found that because `Content-Type` was forcibly set to `application/x-www-form-urlencoded`, instead of requested `{"name": "John"}` the controller received:

```
{"{\"name\": \"John\"}" => [""]
```

The simplest fix was to skip overriding `Content-Type` header if it has already been explicitly set in the test request. I added two tests to show how it works. I haven't added them to the rest of HTTP verbs, but maybe they should be there too.