### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ jdk:
 crystal:
   - latest
 install: # Install ChromeDriver (64bits; replace 64 with 32 for 32bits).
-  - brew install chromedriver
+  - brew tap homebrew/cask
+  - brew cask install chromedriver
   - brew install selenium-server-standalone
 before_script:
   - selenium-server -port 4000 &


### PR DESCRIPTION
Fixes error:

```
2.60s$ brew install chromedriver
Error: No available formula with the name "chromedriver" 
It was migrated from homebrew/core to homebrew/cask.
You can access it again by running:
  brew tap homebrew/cask
And then you can install it by running:
  brew cask install chromedriver
```

https://travis-ci.org/katafrakt/garnet-spec/builds/392639744?utm_source=email&utm_medium=notification